### PR TITLE
Release v2.1.1 — Fix timezone/DST offset bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ It has been completely refactored for maintainability and ease of feature additi
 
 # Release Notes
 
+## v2.1.1 — 2026-04-11
+
+### Bug Fixes
+
+- **Time display off by +1 or +2 hours** — Several related timezone/DST bugs that could cause the clock to show the wrong time have been fixed:
+
+  - If the timezone lookup service (`timeapi.io`) returned an empty or null timezone name, the device's POSIX timezone string was silently cleared, reverting the clock to UTC. For a UTC+2 (CEST) user this showed as 2 hours behind. The device now falls back to a UTC-offset-derived rule and preserves the previously working timezone.
+
+  - When `timeapi.io` was unreachable, the hardcoded country-level fallback incorrectly overwrote the active timezone with a regional guess (e.g. all of US/Canada → Eastern Time). The device now keeps the existing timezone when the service is unavailable.
+
+  - The standard UTC offset and DST offset were stored incorrectly in NVS — the DST-inclusive offset was saved as the base offset, so the Manual timezone screen showed the wrong base hour. Both values are now stored correctly.
+
+  - In Auto region mode, the weather update (every 30 minutes) was silently overwriting a manually-set timezone. The timezone refresh is now skipped when Manual mode is active.
+
+  - On boot, the saved POSIX timezone string was unnecessarily re-derived from the IANA timezone name for any device that happened to have the Central European default string stored — even if it was legitimately set. Fixed.
+
 ## v2.1.0 — 2026-03-25
 
 ### New Features

--- a/src/app/location.cpp
+++ b/src/app/location.cpp
@@ -297,8 +297,10 @@ void loadSavedLocation() {
             selectedCountry = "";
             log_d( "[LOAD] Cleared stale Czech Republic country default (timezone: %s)", selectedTimezone.c_str() );
         }
-        // If posixTZ was not saved (old firmware version), derive it from IANA timezone
-        if ( posixTZ == "" || posixTZ == "CET-1CEST,M3.5.0,M10.5.0/3" ) {
+        // If posixTZ was not saved (old firmware upgrade path), derive it from the saved IANA zone.
+        // Checking for "" only — the previous check also matched the legitimate Prague POSIX
+        // string for users who correctly had it saved, causing an unnecessary re-derivation.
+        if ( posixTZ == "" ) {
             if ( selectedTimezone != "" ) {
                 posixTZ = ianaToPostfixTZ( selectedTimezone );
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,7 +69,7 @@ bool invertColors = false;  // NEW VARIABLE: Invert colors for CYD boards with i
 bool displayFlipped = false; // true = rotation 3 (180° flipped), false = rotation 1 (normal)
 
 // ================= OTA UPDATE GLOBALS =================
-const char *FIRMWARE_VERSION = "2.1.0";  // CURRENT VERSION
+const char *FIRMWARE_VERSION = "2.1.1";  // CURRENT VERSION
 const char *VERSION_CHECK_URL = "https://raw.githubusercontent.com/Xylopyrographer/CYD_DD/main/version.json";
 const char *FIRMWARE_URL = "https://github.com/lachimalaif/DataDisplay-V1-instalator/releases/latest/download/DataDisplayCYD.ino.bin";
 

--- a/src/net/timezone.cpp
+++ b/src/net/timezone.cpp
@@ -160,11 +160,8 @@ String ianaToPostfixTZ( String iana ) {
 
 void detectTimezoneFromCoords( float lat, float lon, String countryHint ) {
     if ( WiFi.status() != WL_CONNECTED ) {
-        log_w( "[TZ-AUTO] WiFi not connected, using fallback" );
-        lookupTimezone = "Europe/Prague";
-        lookupGmtOffset = 3600;
-        lookupDstOffset = 3600;
-        posixTZ = "CET-1CEST,M3.5.0,M10.5.0/3";
+        log_w( "[TZ-AUTO] WiFi not connected, keeping existing posixTZ: %s", posixTZ.c_str() );
+        // Don't overwrite posixTZ — the saved/derived value is more accurate than any guess.
         return;
     }
 
@@ -208,9 +205,12 @@ void detectTimezoneFromCoords( float lat, float lon, String countryHint ) {
             log_d( "[TZ-AUTO] Found: %s currentOffset: %ds, hasDST: %d", ianaName.c_str(), currentOffset, hasDst );
 
             // Store data
-            lookupTimezone = ( ianaName != "" ) ? ianaName : "UTC";
-            lookupGmtOffset = currentOffset;
-            lookupDstOffset = 0;
+            // Bug fix: store the standard (non-DST) offset so the manual Regional
+            // Settings screen shows the correct base offset, and lookupDstOffset
+            // correctly reflects whether DST is currently applied.
+            lookupTimezone  = ( ianaName != "" ) ? ianaName : "UTC";
+            lookupGmtOffset = standardOffset;                          // was: currentOffset (DST-inclusive)
+            lookupDstOffset = currentOffset - standardOffset;          // was: always 0
 
             // 5. Try ianaToPostfixTZ for accurate DST rules (works for Europe, major US cities, etc.)
             String newPosix = "";
@@ -219,13 +219,15 @@ void detectTimezoneFromCoords( float lat, float lon, String countryHint ) {
             }
 
             // 6. If ianaToPostfixTZ returns unknown zone ("UTC0" for a non-UTC zone),
-            //    build POSIX string directly from the offset
-            bool isUnknownZone = ( newPosix == "UTC0" &&
+            //    OR returns an empty string (timeapi.io returned a null/empty timeZone),
+            //    build POSIX string directly from the current (DST-inclusive) offset.
+            bool isUnknownZone = ( ( newPosix == "UTC0" || newPosix == "" ) &&
                                    ianaName != "" &&
                                    ianaName.indexOf( "UTC" ) < 0 &&
                                    ianaName.indexOf( "GMT" ) < 0 );
+            bool isEmptyIana   = ( ianaName == "" );  // timeapi.io returned no zone name at all
 
-            if ( isUnknownZone ) {
+            if ( isUnknownZone || isEmptyIana ) {
                 // POSIX string has OPPOSITE sign to UTC offset
                 // UTC+7 (offset=+25200) → POSIX "UTC-7"
                 // UTC-7 (offset=-25200) → POSIX "UTC7"
@@ -242,7 +244,15 @@ void detectTimezoneFromCoords( float lat, float lon, String countryHint ) {
                 }
             }
 
-            posixTZ = newPosix;
+            // Guard: only update posixTZ if we produced a valid non-empty string.
+            // An empty newPosix (e.g. timeapi.io returned null timeZone AND currentOffset==0
+            // is indistinguishable from UTC) would silently reset the clock to UTC.
+            if ( newPosix != "" ) {
+                posixTZ = newPosix;
+            }
+            else {
+                log_w( "[TZ-AUTO] Could not derive POSIX TZ — keeping previous value: %s", posixTZ.c_str() );
+            }
             log_i( "[TZ-AUTO] POSIX TZ set to: %s", posixTZ.c_str() );
             http.end();
             return;
@@ -257,36 +267,35 @@ void detectTimezoneFromCoords( float lat, float lon, String countryHint ) {
     }
     http.end();
 
-    // Fallback if timeapi.io fails
-    log_w( "[TZ-AUTO] timeapi.io failed, using basic fallback" );
+    // Fallback if timeapi.io fails.
+    // IMPORTANT: Do NOT overwrite posixTZ here. Any country-level guess (e.g. all of
+    // US/Canada → Eastern) is coarser than what applyLocation() already set from the
+    // IANA table, and coarser than whatever was saved to NVS from a prior successful call.
+    // We only update the informational lookup* globals so callers can display them.
+    log_w( "[TZ-AUTO] timeapi.io failed — keeping existing posixTZ: %s", posixTZ.c_str() );
     if ( countryHint == "United Kingdom" || countryHint == "Ireland" || countryHint == "Portugal" ) {
-        lookupTimezone = "Europe/London";
+        lookupTimezone  = "Europe/London";
         lookupGmtOffset = 0;
         lookupDstOffset = 3600;
-        posixTZ = "GMT0BST,M3.5.0/1,M10.5.0";
     }
     else if ( countryHint == "China" ) {
-        lookupTimezone = "Asia/Shanghai";
+        lookupTimezone  = "Asia/Shanghai";
         lookupGmtOffset = 28800;
         lookupDstOffset = 0;
-        posixTZ = "CST-8";
     }
     else if ( countryHint == "Japan" ) {
-        lookupTimezone = "Asia/Tokyo";
+        lookupTimezone  = "Asia/Tokyo";
         lookupGmtOffset = 32400;
         lookupDstOffset = 0;
-        posixTZ = "JST-9";
     }
     else if ( countryHint.indexOf( "America" ) >= 0 || countryHint == "United States" || countryHint == "Canada" ) {
-        lookupTimezone = "America/New_York";
+        lookupTimezone  = "America/New_York";
         lookupGmtOffset = -18000;
         lookupDstOffset = 3600;
-        posixTZ = "EST5EDT,M3.2.0,M11.1.0";
     }
     else {
-        lookupTimezone = "Europe/Prague";
+        lookupTimezone  = "Europe/Prague";
         lookupGmtOffset = 3600;
         lookupDstOffset = 3600;
-        posixTZ = "CET-1CEST,M3.5.0,M10.5.0/3";
     }
 }

--- a/src/net/weather_api.cpp
+++ b/src/net/weather_api.cpp
@@ -22,6 +22,7 @@ extern Preferences prefs;
 extern String      posixTZ;
 extern int         lookupGmtOffset;
 extern int         lookupDstOffset;
+extern bool        regionAutoMode;
 
 extern const char *ntpServer;
 extern int         lastDay;
@@ -164,8 +165,9 @@ void fetchWeatherData() {
     }
 
     // STEP 1b: Refresh timezone from timeapi.io (every 30 min = every weather update)
-    // This automatically corrects DST transitions anywhere in the world
-    if ( lat != 0.0 || lon != 0.0 ) {
+    // This automatically corrects DST transitions anywhere in the world.
+    // Guard: only run in auto mode — manual timezone set by the user must not be overwritten.
+    if ( regionAutoMode && ( lat != 0.0 || lon != 0.0 ) ) {
         String oldPosix = posixTZ;
         detectTimezoneFromCoords( lat, lon, selectedCountry );
         // detectTimezoneFromCoords set the global posixTZ

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.1.0",
-  "download_url": "https://github.com/Xylopyrographer/CYD_DD/releases/download/v2.1.0/CYD_DataDisplay_v2.1.0_R_OTA.bin",
-  "changelog": "Adds digital clock seconds toggle and seconds font change.",
+  "version": "2.1.1",
+  "download_url": "https://github.com/Xylopyrographer/CYD_DD/releases/download/v2.1.1/CYD_DataDisplay_v2.1.1_R_OTA.bin",
+  "changelog": "Fix timezone/DST bugs: guard against empty posixTZ from API failure, correct standard vs DST offset storage, prevent weather update from overwriting manual timezone.",
   "min_version": "2.0.0",
   "force_update": false
 }


### PR DESCRIPTION
## Summary

Fixes several related bugs that caused the clock to display the wrong time (+1 or +2 hours).

## Bug Fixes

- **posixTZ cleared on null API response** — If `timeapi.io` returned a null/empty timezone name, `posixTZ` was silently set to `""`, reverting the clock to UTC.
- **Fallback overwrites active timezone** — When `timeapi.io` was unreachable, the hardcoded country fallback (e.g. all US/Canada → Eastern) overwrote the correct timezone. Now keeps the existing value.
- **DST-inclusive offset saved as base offset** — `lookupGmtOffset` stored the DST-inclusive current offset instead of the standard offset. Now stores `standardOffset` correctly.
- **Weather update overwrites manual timezone** — The 30-minute timezone refresh ran regardless of Auto/Manual mode. Now guarded by `regionAutoMode`.
- **False-positive posixTZ re-derivation on boot** — `loadSavedLocation()` re-derived posixTZ for any device with the Prague default string saved (including legitimate Prague users). Condition tightened to empty string only.

## Files Changed
- `src/net/timezone.cpp`
- `src/net/weather_api.cpp`
- `src/app/location.cpp`
- `src/main.cpp` (version bump to 2.1.1)
- `version.json` (OTA version, URL, changelog)
- `README.md` (release notes)